### PR TITLE
updated JP translations, and changed the font style setting of taunt frames.

### DIFF
--- a/Untaunted/Untaunted.lua
+++ b/Untaunted/Untaunted.lua
@@ -133,7 +133,7 @@ local function NewItem(unitname, unitId, abilityId)  -- Adds an item to the taun
 	local label = item:GetNamedChild("Label")
 
 	label:SetText(zo_strformat("<<!aC:1>>",unitname))
-	label:SetFont("EsoUi/Common/Fonts/Univers57.otf".."|"..db.window.height-(4*dx)..'|soft-shadow-thin')
+	label:SetFont("$(MEDIUM_FONT)".."|"..db.window.height-(4*dx)..'|soft-shadow-thin')
 
 	local bg = item:GetNamedChild("Bg")
 
@@ -151,7 +151,7 @@ local function NewItem(unitname, unitId, abilityId)  -- Adds an item to the taun
 	local timer = item:GetNamedChild("Timer")
 
 	timer:SetHeight(db.window.height)
-	timer:SetFont("EsoUi/Common/Fonts/Univers57.otf".."|"..db.window.height-(4*dx)..'|soft-shadow-thin')
+	timer:SetFont("$(MEDIUM_FONT)".."|"..db.window.height-(4*dx)..'|soft-shadow-thin')
 	timer:SetText("15.0")
 
 	lastanchor[2].anchored = item  -- stores a reference to the item at the item it is anchored to. This is needed when redirecting anchors when an item is removed (see below)

--- a/Untaunted/lang/jp.lua
+++ b/Untaunted/lang/jp.lua
@@ -1,17 +1,26 @@
 -- translated by @h.metaverse
+-- updated Japanese translation by Calamath
 
 -- Menu --
 
-SafeAddString(SI_COMBAT_METRICS_LANG, "jp", 1)
+SafeAddString(SI_UNTAUNTED_LANG, "jp", 1)
+SafeAddString(SI_UNTAUNTED_MENU_AW_NAME, "アカウント共通の設定を使う",  1)	-- "Use Accountwide Settings"
+SafeAddString(SI_UNTAUNTED_MENU_AW_NAME_TOOLTIP, "選択すると、このアカウントのすべてのキャラクターが同じ設定になります",  1)	-- "If chosen all characters on this account will have the same Settings"
 SafeAddString(SI_UNTAUNTED_MENU_MOVE_BUTTON, "移動", 1)
 SafeAddString(SI_UNTAUNTED_MENU_MOVE_BUTTON_TOOLTIP, "フレームを移動します", 1)
 SafeAddString(SI_UNTAUNTED_MENU_WINDOW_WIDTH, "横幅", 1)
 SafeAddString(SI_UNTAUNTED_MENU_WINDOW_WIDTH_TOOLTIP, "フレームの横幅を設定します", 1)
 SafeAddString(SI_UNTAUNTED_MENU_WINDOW_HEIGHT, "高さ", 1)
 SafeAddString(SI_UNTAUNTED_MENU_WINDOW_HEIGHT_TOOLTIP, "フレームの高さを設定します", 1)
-SafeAddString(SI_UNTAUNTED_MENU_GROWTH_DIRECTION, "挑発バーを上方向に追加", 1)
-SafeAddString(SI_UNTAUNTED_MENU_GROWTH_DIRECTION_TOOLTIP, "選択すると、新しい挑発バーは上方向に積み上げて表示します", 1)
+SafeAddString(SI_UNTAUNTED_MENU_GROWTH_DIRECTION, "フレームを上方向に追加", 1)
+SafeAddString(SI_UNTAUNTED_MENU_GROWTH_DIRECTION_TOOLTIP, "選択すると、新しいフレームを上方向に積み上げて表示します", 1)
+SafeAddString(SI_UNTAUNTED_MENU_MAX_BARS, "最大行数",  1)	-- "Maximum Rows"
+SafeAddString(SI_UNTAUNTED_MENU_MAX_BARS_TOOLTIP, "フレームの表示行数の最大値を設定します",  1)	-- "Maximum number of rows to show"
 SafeAddString(SI_UNTAUNTED_MENU_BAR_DIRECTION, "タイマーバーの反転", 1)
-SafeAddString(SI_UNTAUNTED_MENU_BAR_DIRECTION_TOOLTIP, "選択すると、タイマーバーが右に減少します", 1)
+SafeAddString(SI_UNTAUNTED_MENU_BAR_DIRECTION_TOOLTIP, "選択すると、タイマーバーが右方向に減少します", 1)
 SafeAddString(SI_UNTAUNTED_MENU_SHOWMARKER, "敵のマーカーの表示", 1)
-SafeAddString(SI_UNTAUNTED_MENU_SHOWMARKER_TOOLTIP, "あなたの戦闘に従事して敵の上にグループ・ピンのようなマーカーを表示するかどうかを設定します", 1)
+SafeAddString(SI_UNTAUNTED_MENU_SHOWMARKER_TOOLTIP, "戦闘状態の敵の頭上にグループ・ピンのようなマーカーを表示するか設定します", 1)
+SafeAddString(SI_UNTAUNTED_MENU_TRACKONLYPLAYER, "プレイヤーエフェクトのみ",  1)	-- "Only Player Effects"
+SafeAddString(SI_UNTAUNTED_MENU_TRACKONLYPLAYER_TOOLTIP, "プレイヤーがキャストした効果（バフ）のみを監視する場合に選択します",  1)	-- "Select to track only Player Effects"
+SafeAddString(SI_UNTAUNTED_MENU_TRACK, "%s を監視する",  1)	-- e.g. "Track Taunt"
+SafeAddString(SI_UNTAUNTED_MENU_TRACK_TOOLTIP, "%s を監視する場合に選択します",  1)	-- e.g. "Select to track Taunts"


### PR DESCRIPTION
With Update 25, the behavior of the ESO fallback font has changed so that Untaunted add-on can no longer correctly display localized text in Japanese language mode. This change resolves the issue without affecting any behavior in other language modes.

[details]
MEDIUM_FONT is defined in ESOUI fontstrings, and the font itself is the same as univers57.otf. Therefore, there is no operational change in three official language modes, EN, DE, and FR.

Please see below, if you need confirm definitions.
https://github.com/esoui/esoui/blob/master/esoui/fontstrings/western/defaultfontstrings_western.xml
https://github.com/esoui/esoui/blob/master/esoui/fontstrings/japanese/defaultfontstrings_japanese.xml

In addition, I updated the Japanese language file to the latest one. Many Japanese tanks love this wonderful add-on.
Thank you.